### PR TITLE
회원 탈퇴 API

### DIFF
--- a/src/main/java/com/bside/gamjajeon/domain/record/entity/Image.java
+++ b/src/main/java/com/bside/gamjajeon/domain/record/entity/Image.java
@@ -23,7 +23,7 @@ public class Image extends BaseEntity {
     @Column(name = "image_id")
     private Long id;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     @JoinColumn(name = "record_id")
     private Record record;
 

--- a/src/main/java/com/bside/gamjajeon/domain/record/entity/Record.java
+++ b/src/main/java/com/bside/gamjajeon/domain/record/entity/Record.java
@@ -30,7 +30,7 @@ public class Record extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @OneToOne(mappedBy = "record")
+    @OneToOne(mappedBy = "record", cascade = CascadeType.ALL)
     private Image image;
 
     @Comment("포스트 내용")

--- a/src/main/java/com/bside/gamjajeon/domain/record/entity/RecordHashtag.java
+++ b/src/main/java/com/bside/gamjajeon/domain/record/entity/RecordHashtag.java
@@ -3,14 +3,7 @@ package com.bside.gamjajeon.domain.record.entity;
 import static javax.persistence.GenerationType.*;
 import static lombok.AccessLevel.*;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import com.bside.gamjajeon.global.common.entity.BaseEntity;
 

--- a/src/main/java/com/bside/gamjajeon/domain/record/repository/RecordRepository.java
+++ b/src/main/java/com/bside/gamjajeon/domain/record/repository/RecordRepository.java
@@ -1,8 +1,10 @@
 package com.bside.gamjajeon.domain.record.repository;
 
+import com.bside.gamjajeon.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.bside.gamjajeon.domain.record.entity.Record;
 
 public interface RecordRepository extends JpaRepository<Record, Long> {
+    void deleteByUser(User user);
 }

--- a/src/main/java/com/bside/gamjajeon/domain/user/api/UserController.java
+++ b/src/main/java/com/bside/gamjajeon/domain/user/api/UserController.java
@@ -76,4 +76,10 @@ public class UserController {
         return ApiResponse.empty();
     }
 
+    @DeleteMapping
+    public ApiResponse<Object> withdraw(@AuthUser CustomUserDetails userDetails) {
+        userService.withdraw(userDetails.getUser());
+        return ApiResponse.empty();
+    }
+
 }

--- a/src/main/java/com/bside/gamjajeon/domain/user/service/UserService.java
+++ b/src/main/java/com/bside/gamjajeon/domain/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.bside.gamjajeon.domain.user.service;
 
+import com.bside.gamjajeon.domain.record.repository.RecordRepository;
 import com.bside.gamjajeon.domain.user.dto.request.*;
 import com.bside.gamjajeon.domain.user.dto.response.LoginResponse;
 import com.bside.gamjajeon.domain.user.dto.response.UsernameResponse;
@@ -35,6 +36,7 @@ public class UserService {
     private final CustomJwtProvider provider;
     private final JwtUtil jwtUtil;
     private final PasswordEncoder passwordEncoder;
+    private final RecordRepository recordRepository;
 
     @Transactional
     public LoginResponse signup(SignupRequest signupRequest) {
@@ -95,5 +97,11 @@ public class UserService {
         String newPassword = passwordEncoder.encode(passwordRequest.getPassword());
         user.setPassword(newPassword);
         userRepository.save(user);
+    }
+
+    @Transactional
+    public void withdraw(User user) {
+        recordRepository.deleteByUser(user);
+        userRepository.delete(user);
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
- 회원 탈퇴 API 추가
  - `record`, `image`, `record_hashtag` 데이터 함께 삭제
  - `hashtag` 데이터는 삭제 되지 않음 (한 사용자에게만 속하는 데이터는 아니라서 삭제 처리 안 함)
  - `is_deleted` 컬럼이 있으나 논리 삭제 대신 물리 삭제 처리

담이님 처음에는 사용자 탈퇴할 때 `is_deleted` 값을 1로 변경하고 배치 서버를 따로 둬서
해당 데이터를 삭제하는 작업을 하려고 저 컬럼을 두었는데 배치 서버까지 두는 게 지금은 어렵지 않을까 생각이 들어서
물리 삭제하도록 해놨어요. 해시태그 데이터가 삭제되지 않는 것과 삭제 방식에 대해서는 같이 논의해보아요~!


뭔가 제가 코드 포맷팅 할 때랑 담이님이 할 때랑 서로 설정이 다른가봐요
제가 구글껄로 되어 있을 수도 있어서 한 번 확인해볼게요! 
Files changed 보니 포맷팅 때문에 나온 게 많네요 ;;; 

