### PR TITLE
JWT 만료될 경우, 상태 코드 401로 변경

### DIFF
--- a/src/main/java/com/bside/gamjajeon/global/security/filter/ExceptionHandlerFilter.java
+++ b/src/main/java/com/bside/gamjajeon/global/security/filter/ExceptionHandlerFilter.java
@@ -36,18 +36,19 @@ public class ExceptionHandlerFilter extends OncePerRequestFilter {
         try {
             filterChain.doFilter(request, response);
         } catch (ExpiredJwtException e) {
-            setResponse(response, ErrorCode.TOKEN_EXPIRED);
+            setResponse(response, ErrorCode.TOKEN_EXPIRED, true);
         } catch (GeneralException e) {
-            setResponse(response, e.getErrorCode());
+            setResponse(response, e.getErrorCode(), false);
         } catch (HttpMessageNotReadableException e) {
-            setResponse(response, ErrorCode.VALIDATION_ERROR);
+            setResponse(response, ErrorCode.VALIDATION_ERROR, false);
         } catch (SignatureException | MalformedJwtException e) {
-            setResponse(response, ErrorCode.TOKEN_INVALID);
+            setResponse(response, ErrorCode.TOKEN_INVALID, false);
         }
     }
 
-    private void setResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException {
-        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+    private void setResponse(HttpServletResponse response, ErrorCode errorCode, boolean isTokenExpired) throws IOException {
+        int status = isTokenExpired ? HttpServletResponse.SC_UNAUTHORIZED : HttpServletResponse.SC_BAD_REQUEST;
+        response.setStatus(status);
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");
         response.getWriter()


### PR DESCRIPTION
## 📝 작업 내용
- JWT 만료될 경우, 상태 코드 401로 변경
- 클라이언트에서 토큰 생성 API 호출하기 위해 상태 코드 구분 필요


